### PR TITLE
fix: configure GitHub Actions to ignore tags

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,7 +8,8 @@ on:  # yamllint disable-line rule:truthy
       - dist.ini
   pull_request:
     branches:
-      - main
+      # ignores new tags pushed
+      - '**'
 jobs:
   prove:
     name: prove CLI execution


### PR DESCRIPTION
At each tag creation and pushed after branches merging, the GHA is being executed again, without any need.