### PR TITLE
Bugfix/arm 7

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -11,8 +11,6 @@ requires "Regexp::Common" => "2017060201";
 requires "Set::Tiny" => "0.04";
 requires "Time::HiRes" => "1.9764";
 requires "YAML::XS" => "0.88";
-requires "overload" => "0";
-requires "parent" => "0";
 requires "perl" => "5.012000";
 
 on 'test' => sub {
@@ -32,6 +30,7 @@ on 'test' => sub {
 };
 
 on 'configure' => sub {
+  requires "Devel::AssertOS" => "1.21";
   requires "ExtUtils::MakeMaker" => "0";
   requires "perl" => "5.012000";
 };

--- a/dist.ini
+++ b/dist.ini
@@ -1,9 +1,9 @@
 name = Linux-Info
-copyright_year   = 2015
+copyright_year = 2015
 author  = Alceu Rodrigues de Freitas Junior <glasswalk3r@yahoo.com.br>
 copyright_holder = Alceu Rodrigues de Freitas Junior
 license = GPL_3
-version = 2.18
+version = 2.19
 
 [GatherDir]
 exclude_filename = cpanfile

--- a/lib/Linux/Info/SysInfo.pm
+++ b/lib/Linux/Info/SysInfo.pm
@@ -400,8 +400,14 @@ sub _set_cpuinfo {
         my $data = <$fh>;
         close($fh);
 
-        confess
-"Failed to recognize the processor, submit the /proc/cpuinfo to this project as an issue.\n$data";
+        my @msg = (
+            'Failed to recognize the processor,',
+            'please submit the /proc/cpuinfo content below',
+            'to this project as an issue',
+            "\n$data\n",
+        );
+
+        confess join( ' ', @msg );
     }
 
     $self->{cpu} = "Linux::Info::SysInfo::CPU::$model"->new($filename);
@@ -411,15 +417,17 @@ sub _set_interfaces {
     my $self  = shift;
     my $class = ref($self);
     my $file  = $self->{files};
-    my @iface = ();
+    my @iface;
 
     my $filename = $file->{netdev};
     open my $fh, '<', $filename
       or confess "$class: unable to open $filename ($!)";
     { my $head = <$fh>; }
 
+    my $regex = qr/^\s*(\w+):/;
+
     while ( my $line = <$fh> ) {
-        if ( $line =~ /^\s*(\w+):/ ) {
+        if ( $line =~ $regex ) {
             push @iface, $1;
         }
     }

--- a/lib/Linux/Info/SysInfo/CPU/Arm.pm
+++ b/lib/Linux/Info/SysInfo/CPU/Arm.pm
@@ -2,8 +2,15 @@ package Linux::Info::SysInfo::CPU::Arm;
 use strict;
 use warnings;
 use Carp qw(confess);
-use Class::XSAccessor getters =>
-  { get_variant => 'variant', get_part => 'part', get_revision => 'revision' };
+use Class::XSAccessor getters => {
+    get_variant      => 'variant',
+    get_part         => 'part',
+    get_revision     => 'revision',
+    get_hardware     => 'hardware',
+    get_serial       => 'serial',
+    get_model_name   => 'model_name',
+    get_cpu_revision => 'cpu_revision',
+};
 
 use base 'Linux::Info::SysInfo::CPU';
 
@@ -20,7 +27,10 @@ See L<Linux::Info::SysInfo> C<get_cpu> method.
 This is a subclass of L<Linux::Info::SysInfo::CPU>, with specific code to parse
 ARM format of L</proc/cpuinfo>.
 
-Finding information about a ARM processor can be quite difficult. Not all
+ARM processor information parsing is a pain in the ass. Manufactures basically
+add whatever information they want, and there are several manufactures.
+
+Finding information about a ARM processor can also be quite difficult. Not all
 vendors have model information available on the L</proc/cpuinfo> file, and
 sometimes is required to even search specifications for a processor using the
 following attributes in this class:
@@ -64,7 +74,7 @@ Returns a regular expression that identifies the processor that is being read.
 =cut
 
 # CPU architecture: 8
-my $processor_regex = qr/^CPU\sarchitecture\:\s8$/;
+my $processor_regex = qr/^CPU\sarchitecture\:\s\d+$/;
 
 sub processor_regex {
     return $processor_regex;
@@ -84,45 +94,59 @@ my %vendors = (
 );
 
 sub _parse {
-    my $self = shift;
-    my $file = $self->{source_file};
-
-# Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop
-    my $flags_regex   = qr/^Features\t\:\s+(.*)/;
-    my $flags_defined = 0;
-
-    # CPU implementer	: 0x41
-    my $vendor_regex = qr/CPU\simplementer\t\:\s(0x\d+)/;
-
-    # BogoMIPS	: 50.00
-    my $bogo_regex = qr/BogoMIPS\t\:\s(\d+\.\d+)/;
-
-    # processor	: 0
-    my $processor_regex = qr/^processor\t\:\s(\d)/;
-
-    # CPU variant	: 0x3
-    my $variant_regex = qr/^CPU\svariant\t\:\s(0x\w+)/;
-
-    # CPU part	: 0xd0c
-    my $part_regex = qr/^CPU\spart\t\:\s(0x\w+)/;
-
-    # CPU revision	: 1
-    my $revision_regex = qr/^CPU\srevision\t\:\s(\d+)/;
-
-    # CPU architecture: 8
-    my $arch_regex = qr/^CPU\sarchitecture\:\s(\d+)/;
-
-    # Processor       : ARMv7 Processor rev 10 (v7l)
-    # model name      : ARMv7 Processor rev 10 (v7l)
-    # Hardware        : Generic DT based system
-    my $model_regex = qr/^(Processor|model\sname|Hardware)\s+\:\s(.*)/;
-    my $processors  = 0;
+    my $self               = shift;
+    my $file               = $self->{source_file};
+    my $flags_regex        = qr/^Features\t\:\s+(.*)/;
+    my $flags_defined      = 0;
+    my $vendor_regex       = qr/CPU\simplementer\t\:\s(0x\d+)/;
+    my $bogo_regex         = qr/BogoMIPS\t\:\s(\d+\.\d+)/;
+    my $processor_regex    = qr/^processor\t\:\s(\d)/;
+    my $variant_regex      = qr/^CPU\svariant\t\:\s(0x\w+)/;
+    my $part_regex         = qr/^CPU\spart\t\:\s(0x\w+)/;
+    my $cpu_revision_regex = qr/^CPU\srevision\t\:\s(\d+)/;
+    my $arch_regex         = qr/^CPU\sarchitecture\:\s(\d+)/;
+    my $hardware_regex     = qr/^Hardware\s+\:\s(.*)/;
+    my $serial_regex       = qr/^Serial\s+\:\s(.*)/;
+    my $revision_regex     = qr/^Revision\s+\:\s(.*)/;
+    my $model_regex        = qr/^Model\s+\:\s(.*)/;
+    my $model_name_regex   = qr/^model\sname\s+\:\s(.*)/;
+    my $processors         = 0;
 
     open( my $fh, '<', $file ) or confess "Cannot read $file: $!";
 
   LINE: while ( my $line = <$fh> ) {
         chomp($line);
         next LINE if ( $line eq '' );
+
+        if ( $line =~ $serial_regex ) {
+            next LINE if ( defined $self->{serial} );
+            $self->{serial} = $1;
+            next LINE;
+        }
+
+        if ( $line =~ $hardware_regex ) {
+            next LINE if ( defined $self->{hardware} );
+            $self->{hardware} = $1;
+            next LINE;
+        }
+
+        if ( $line =~ $model_name_regex ) {
+            next LINE if ( defined $self->{model_name} );
+            $self->{model_name} = $1;
+            next LINE;
+        }
+
+        if ( $line =~ $model_regex ) {
+            next LINE if ( defined $self->{model} );
+            $self->{model} = $1;
+            next LINE;
+        }
+
+        if ( $line =~ $cpu_revision_regex ) {
+            next LINE if ( defined $self->{cpu_revision} );
+            $self->{cpu_revision} = $1;
+            next LINE;
+        }
 
         if ( $line =~ $revision_regex ) {
             next LINE if ( defined $self->{revision} );
@@ -197,7 +221,7 @@ sub _parse {
             ' ',
             (
                 $self->{vendor}, $self->{variant},
-                $self->{part},   $self->{revision}
+                $self->{part},   $self->{cpu_revision}
             )
         );
     }
@@ -215,10 +239,12 @@ sub _set_proc_bits {
 }
 
 sub _custom_attribs {
-    my $self = shift;
-    $self->{variant}  = undef;
-    $self->{part}     = undef;
-    $self->{revision} = undef;
+    my $self    = shift;
+    my @attribs = (
+        'variant',  'part',   'revision', 'model_name',
+        'hardware', 'serial', 'cpu_revision'
+    );
+    map { $self->{$_} = undef } @attribs;
 }
 
 sub _set_hyperthread { }

--- a/lib/Linux/Info/SysInfo/CPU/Arm.pm
+++ b/lib/Linux/Info/SysInfo/CPU/Arm.pm
@@ -259,9 +259,34 @@ sub get_cores {
     return 0;
 }
 
-=head2 get_threads
+# get_hardware     => 'hardware',
+# get_serial       => 'serial',
+# get_model_name   => 'model_name',
+# get_cpu_revision => 'cpu_revision',
 
-Returns the number of threads of the processor.
+=head2 get_hardware
+
+Returns the content of C<Hardware> field on F</proc/cpuinfo> if available.
+
+Otherwise returns C<undef>.
+
+=head2 get_serial
+
+Returns the content of C<Serial> field on F</proc/cpuinfo> if available.
+
+Otherwise returns C<undef>.
+
+=head2 get_model_name
+
+Returns the content of C<model name> field on F</proc/cpuinfo> if available.
+
+Otherwise returns C<undef>.
+
+=head2 get_cpu_revision
+
+Returns the content of C<cpu revision> field on F</proc/cpuinfo> if available.
+
+Otherwise returns C<undef>.
 
 =head2 get_part
 
@@ -274,6 +299,10 @@ Return an hexadecimal of the CPU revision.
 =head2 get_variant
 
 Return an hexadecimal of the CPU variant.
+
+=head2 get_threads
+
+Returns the number of threads of the processor.
 
 =cut
 

--- a/t/cpu-arm.t
+++ b/t/cpu-arm.t
@@ -5,26 +5,62 @@ use Test::More;
 my $class = 'Linux::Info::SysInfo::CPU::Arm';
 
 require_ok($class);
-can_ok( $class, qw(get_variant get_part get_revision) );
+can_ok(
+    $class,
+    (
+        'get_variant',  'get_part', 'get_revision', 'get_model_name',
+        'get_hardware', 'get_serial',
+    )
+);
 
 my $source_file = 't/samples/cpu/info6';
-
+note("Testing with $source_file");
 my $instance = $class->new($source_file);
 isa_ok( $instance, $class );
 
 my @fixtures = (
-    [ 'get_variant',     '0x3' ],
-    [ 'get_part',        '0xd0c' ],
-    [ 'get_revision',    '1' ],
-    [ 'get_model',       'ARM 0x3 0xd0c 1' ],
-    [ 'get_arch',        64 ],
-    [ 'get_bogomips',    50.0 ],
-    [ 'get_source_file', $source_file ],
+    [ 'get_variant',      '0x3' ],
+    [ 'get_part',         '0xd0c' ],
+    [ 'get_cpu_revision', '1' ],
+    [ 'get_revision',     undef ],
+    [ 'get_model',        'ARM 0x3 0xd0c 1' ],
+    [ 'get_arch',         64 ],
+    [ 'get_bogomips',     50.0 ],
+    [ 'get_source_file',  $source_file ],
+    [ 'get_model_name',   undef ],
+    [ 'get_hardware',     undef ],
+    [ 'get_revision',     undef ],
+    [ 'get_serial',       undef ],
 );
 
 foreach my $fixture_ref (@fixtures) {
     my $method = $fixture_ref->[0];
     is( $instance->$method, $fixture_ref->[1], "$method works" );
+}
+
+$source_file = 't/samples/cpu/info9';
+note("Testing with $source_file");
+my $other = $class->new($source_file);
+isa_ok( $other, $class );
+
+@fixtures = (
+    [ 'get_variant',      '0x0' ],
+    [ 'get_part',         '0xb76' ],
+    [ 'get_cpu_revision', 7 ],
+    [ 'get_revision',     '000d' ],
+    [ 'get_model',        'Raspberry Pi Model B Rev 2' ],
+    [ 'get_arch',         32 ],
+    [ 'get_bogomips',     697.95 ],
+    [ 'get_source_file',  $source_file ],
+    [ 'get_model_name',   'ARMv6-compatible processor rev 7 (v6l)' ],
+    [ 'get_hardware',     'BCM2835' ],
+    [ 'get_revision',     '000d' ],
+    [ 'get_serial',       '00000000a5126eb6' ],
+);
+
+foreach my $fixture_ref (@fixtures) {
+    my $method = $fixture_ref->[0];
+    is( $other->$method, $fixture_ref->[1], "$method works" );
 }
 
 done_testing;

--- a/t/samples/cpu/info9
+++ b/t/samples/cpu/info9
@@ -1,0 +1,14 @@
+processor	: 0
+model name	: ARMv6-compatible processor rev 7 (v6l)
+BogoMIPS	: 697.95
+Features	: half thumb fastmult vfp edsp java tls
+CPU implementer	: 0x41
+CPU architecture: 7
+CPU variant	: 0x0
+CPU part	: 0xb76
+CPU revision	: 7
+
+Hardware	: BCM2835
+Revision	: 000d
+Serial		: 00000000a5126eb6
+Model		: Raspberry Pi Model B Rev 2


### PR DESCRIPTION
Different ARM `/proc/cpuinfo` format
    
- expands the attributes
- fixes the regex to match ARM processor
- expands the getters
- expands the unit tests to use two different files

Small improvements:
    
- compiling the regex to avoid recompilation at each line.
- better error message